### PR TITLE
Update dkms-helper

### DIFF
--- a/build_tools/dkms-helper
+++ b/build_tools/dkms-helper
@@ -65,6 +65,7 @@ add() {
         if [ -d .git ]; then
             ${GIT} checkout-index -a --prefix=/usr/src/dahdi-linux-${VERSION}/
         else
+            mkdir -p /usr/src/dahdi-linux-${VERSION}/
             cp -f -r * /usr/src/dahdi-linux-${VERSION}/
         fi
     fi


### PR DESCRIPTION
Corrected issue where expected destination folder does not exists, creating it.
Allows dkms-helper to be run from the dahdi-linux-complete package.
